### PR TITLE
chore: remove quotes from frontmatter dates

### DIFF
--- a/blog/2024-04-30-ctflearn-writeup/_index.md
+++ b/blog/2024-04-30-ctflearn-writeup/_index.md
@@ -1,6 +1,6 @@
 ---
 title: CTF Learn Write Up
-date: "2024-04-30"
+date: 2024-04-30
 author: sugawa197203
 draft: false
 ---

--- a/blog/RiderStudents/index.md
+++ b/blog/RiderStudents/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Riderの無料学生ライセンスを使う"
-date: "2024-08-07"
+date: 2024-08-07
 author: "cocoisbored"
 draft: false
 ---

--- a/blog/UnityLec2024Step0/index.md
+++ b/blog/UnityLec2024Step0/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Unity 講習会 2024 環境構築"
-date: "2024-07-20"
+date: 2024-07-20
 author: "sugawa197203"
 draft: false
 ---

--- a/blog/UnityLec2024Step1/index.md
+++ b/blog/UnityLec2024Step1/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Unity 講習会 2024 入門編"
-date: "2024-07-20"
+date: 2024-07-20
 author: "sugawa197203"
 draft: false
 ---

--- a/blog/UnityLec2024Step2/index.md
+++ b/blog/UnityLec2024Step2/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Unity 講習会 2024 応用編"
-date: "2024-08-21"
+date: 2024-08-21
 author: "sugawa197203"
 draft: false
 ---

--- a/blog/UnityLec2024Step3/index.md
+++ b/blog/UnityLec2024Step3/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Unity 講習会 2024 発展編"
-date: "2024-09-11"
+date: 2024-09-11
 author: "sugawa197203"
 draft: false
 ---

--- a/blog/picogym-exclusive/index.md
+++ b/blog/picogym-exclusive/index.md
@@ -1,6 +1,6 @@
 ---
 title: picoGym Exclusive
-date: "2024-05-26"
+date: 2024-05-26
 author: sugawa197203
 draft: false
 ---

--- a/news/2022-12-mccmmancc2022/index.md
+++ b/news/2022-12-mccmmancc2022/index.md
@@ -1,7 +1,7 @@
 ---
 title: MCCMMANCC2022を行いました
 description: MCCMMANCC2022を行いました
-date: "2022-12-17"
+date: 2022-12-17
 tags: [lt]
 draft: false
 ---


### PR DESCRIPTION
## Summary
- remove quotes from `date` fields in frontmatter for several Markdown posts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ad5b874248323a12ecdc20c06aac7